### PR TITLE
Feature: improve xbow:get-type

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -279,7 +279,10 @@ will throw an **exception**!
 - [ ] Generate XQDoc documentation at build
 
 - [x] Replace `ant` with `gulp-exist` +watcher 
-- [ ] Create packages for other XQuery runtimes
+- [ ] ~~Create packages for other XQuery runtimes~~
+- [ ] Split up into modules with separate scopes (DOM, utility, ...)
+- [ ] Add element constructors (inspired by Micheal Kays proposal)
+- [ ] Rename `xbow:groupBy` to `xbow:group-by` to adhere to the XQuery naming convetions
 
 ## Compatibility
 

--- a/README.MD
+++ b/README.MD
@@ -195,8 +195,8 @@ xbow wraps those in functions for you so that you do not have to.
 ```
 
 FLWOR operations allow you to operate on the position of each element.
-`fn:for-each` does not allow that.
-`xbow:for-each-index` adds that. You can operate on a sequence or an array 
+Since `fn:for-each` does not allow that, `xbow:for-each-index` was added.
+It can operate on a sequence or an array.
 
 ```xquery
 (2 to 4)

--- a/README.MD
+++ b/README.MD
@@ -242,6 +242,24 @@ does not contain elements an empty sequence is returned.
 (1, 2, []) => xbow:last() (: returns [] :)
 ```
 
+`xbow:get-type` will return type information of the provided item (not a sequence).
+
+NOTE: It will look deep into the inner structure of the item, if it is nested.
+Sequences as well as arities are not detected. Whenever mixed content is found "*" is returned.
+
+```xquery
+1 => xbow:get-type() (: returns "xs:integer" :)
+```
+
+```xquery
+[1, 2, true()] => xbow:get-type() (: returns "array(*)" :)
+```
+
+```xquery
+[map {1: "one", 2: "two", 9:"nine"}, map {1: "eins", 2: "zwei", 9:"neun"}] 
+  => xbow:get-type() (: returns "array(map(xs:integer, xs:string))" :)
+```
+
 ## General Arrow Syntax
 
 **Remember:**

--- a/README.MD
+++ b/README.MD
@@ -246,14 +246,17 @@ does not contain elements an empty sequence is returned.
 
 **Remember:**
 
+The arrow operator _must_ be followed by a function expression.
+The first argument _will_ be the left hand side, there is no way around that.
+
 ```xquery
-  (0 to 9) => sum(),
-  (0 to 9) => (function($a) { sum($a) })()
+(0 to 9) => sum(),
+(0 to 9) => (function($a) { sum($a) })()
 ```
 is **fine**.
 
 ```xquery
-  (0 to 9) => concat(?)
+(0 to 9) => concat(?)
 ```
 will return **a function** with an arity of 1.
 

--- a/src/test/xbow-spec.xqm
+++ b/src/test/xbow-spec.xqm
@@ -403,6 +403,57 @@ function xbow-spec:map-flip-function-sum () {
 };
 
 declare
+    %test:args('()')
+    %test:assertEquals("item()")
+    %test:args('""')
+    %test:assertEquals("xs:string")
+    %test:args('1')
+    %test:assertEquals("xs:integer")
+    %test:args('1.2')
+    %test:assertEquals("xs:decimal")
+    %test:args('xs:date("1999-01-01")')
+    %test:assertEquals("xs:date")
+    %test:args('xs:QName("test:test")')
+    %test:assertEquals("xs:QName")
+    %test:args('attribute xml:id { "B" }')
+    %test:assertEquals("attribute(xml:id)")
+    %test:args('attribute id { "A" }')
+    %test:assertEquals("attribute(id)")
+    %test:args('element test:test { }')
+    %test:assertEquals("element(test:test)")
+    %test:args('element html { }')
+    %test:assertEquals("element(html)")
+    %test:args('comment { "no comment" }')
+    %test:assertEquals("comment()")
+    %test:args('text { "" }')
+    %test:assertEquals("text()")
+    %test:args('function () as xs:integer { 1 }')
+    %test:assertEquals("function(*)")
+    %test:args('function ($a as node()*) as xs:integer { count($a) }')
+    %test:assertEquals("function(*)")
+    %test:args('map{}')
+    %test:assertEquals("map(*)")
+    %test:args('map{"a": 1, 1: "a"}')
+    %test:assertEquals("map(*)")
+    %test:args('map{"a": "b"}')
+    %test:assertEquals("map(xs:string, xs:string)")
+    %test:args('map{"a": 12}')
+    %test:assertEquals("map(xs:string, xs:integer)")
+    %test:args('map{"a": 12, "b": ()}')
+    %test:assertEquals("map(xs:string, *)")
+    %test:args('map{1: 12, 2: ()}')
+    %test:assertEquals("map(xs:integer, *)")
+    %test:args('[]')
+    %test:assertEquals("array(*)")
+    %test:args('["a", "b"]')
+    %test:assertEquals("array(xs:string)")
+    %test:args('[map{}, map{}]')
+    %test:assertEquals("array(map(*))")
+function xbow-spec:get-type ($type) {
+    util:eval("xbow:get-type(" || $type || ")")
+};
+
+declare
     %test:assertTrue
 function xbow-spec:all-true () {
     $xbow-spec:user-xml/user


### PR DESCRIPTION
xbow:get-type now differentiates most of the builtin atomic types.
For element and attribute nodes the names with namespaces are returned.
Also, text and comment nodes will be detected.
The default value for anything unknown is now "item()".

Biggest upgrade, however, is the detection of structural types.
Given an array of maps with string keys and boolean values
`xbow:get-type` returns "array(map(xs:string, xs:boolean))".